### PR TITLE
Purify by chunk feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports.prototype.apply = function(compiler) {
         // Path/files to check. If none supplied, an empty array will do.
         self.paths = self.userOptions.paths || [];
         // chunk entry files.
-        self.entryPaths = self.userOptions.entryPaths || [];
+        self.entryPaths = self.userOptions.entryPaths;
         // Additional extensions to scan for. This is kept minimal, for obvious reasons.
         // We are not opinionated...
         self.resolveExtensions = self.userOptions.resolveExtensions || compiler.options.resolve.extensions;

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ module.exports.prototype.apply = function(compiler) {
         self.purifyOptions.output = false;
         // Path/files to check. If none supplied, an empty array will do.
         self.paths = self.userOptions.paths || [];
+        self.entryPaths = self.userOptions.entryPaths || [];
         // Additional extensions to scan for. This is kept minimal, for obvious reasons.
         // We are not opinionated...
         self.resolveExtensions = self.userOptions.resolveExtensions || compiler.options.resolve.extensions;
@@ -35,24 +36,80 @@ module.exports.prototype.apply = function(compiler) {
         }, []);
 
         compilation.plugin("additional-assets", function(cb){
-            // Look for additional JS/HTML stuff.
-            for(var key in compilation.fileDependencies) {
-                var file = compilation.fileDependencies[key];
-                var ext = path.extname(file);
-                if (self.resolveExtensions.indexOf(ext) > -1) files.push(file);
+            if (compilation.chunks.length === 1 && compilation.chunks[0].name === 'main') {
+                // main chunk
+                // Look for additional JS/HTML stuff.
+                for(var key in compilation.fileDependencies) {
+                    var file = compilation.fileDependencies[key];
+                    var ext = path.extname(file);
+                    if (self.resolveExtensions.indexOf(ext) > -1) files.push(file);
+                }
+
+                // Look for purifyable CSs...
+                for(var key in compilation.assets) {
+                    if(/\.css$/i.test(key)) {
+                        // We found a CSS. So purify it.
+                        var asset = compilation.assets[key];
+                        executePurification(files, asset, key);
+                    }
+                }
+            } else {
+                // multiple entry chunks
+                var cssAsset;
+                var assets = Object.keys(compilation.assets);
+
+                compilation.chunks.forEach(function (chunk, i) {
+                    // extract html chunk files
+                    var key;
+                    var error = false;
+
+                    if (self.entryPaths[chunk.name]) {
+                        var chunkFiles = self.entryPaths[chunk.name].reduce(function (results, p) {
+                            return results.concat(glob(path.join(self.basePath, p)));
+                        }, []);   
+                    } else {
+                        console.log('Wrong entryPath for ' + chunk.name);
+                        error = true;
+                    }
+
+                    // filter chunk modules for additional files to include ex. .js, .es6,...
+                    var chunkModules = chunk.modules.filter(function (module) {
+                        var ext = path.extname(module.resource);
+                        return self.resolveExtensions.indexOf(ext) > -1;
+                    });
+
+                    // include additional modules
+                    chunkFiles.concat(chunkModules);
+
+                    // find css asset
+                    for (var k = 0; k < assets.length; k++){
+                        if (assets[k].indexOf(chunk.name) > -1 && path.extname(assets[k]) === '.css') {
+                            cssAsset = compilation.assets[assets[k]];
+                            key = assets[k];
+                            break;
+                        }
+                    }
+
+                    if (cssAsset && !error) {
+                        if (self.purifyOptions.info) {
+                            console.log(chunk.name);
+                        }
+
+                        executePurification(chunkFiles, cssAsset, key);
+                    } else {
+                        console.log('No CSS for chunk: ' + chunk.name);
+                    }
+                });
             }
 
-            // Look for purifyable CSs...
-            for(var key in compilation.assets) {
-                if(/\.css/i.test(key)) {
-                    // We found a CSS. So purify it.
-                    var asset = compilation.assets[key];
-                    var css = asset.source();
-                    var newCss = new ConcatSource();
-                    newCss.add(purify(files, css, self.purifyOptions));
-                    compilation.assets[key] = newCss;
-                }
+            function executePurification(files, cssAsset, key) {
+                var css = cssAsset.source();
+                var newCss = new ConcatSource();
+
+                newCss.add(purify(files, css, self.purifyOptions));
+                compilation.assets[key] = newCss;
             }
+
             cb();
         });
     });

--- a/index.js
+++ b/index.js
@@ -26,13 +26,14 @@ module.exports.prototype.apply = function(compiler) {
         self.purifyOptions.output = false;
         // Path/files to check. If none supplied, an empty array will do.
         self.paths = self.userOptions.paths || [];
+        // chunk entry files.
         self.entryPaths = self.userOptions.entryPaths || [];
         // Additional extensions to scan for. This is kept minimal, for obvious reasons.
         // We are not opinionated...
         self.resolveExtensions = self.userOptions.resolveExtensions || compiler.options.resolve.extensions;
 
         var files = self.paths.reduce(function(results, p) {
-          return results.concat(glob(path.join(self.basePath, p)));
+            return results.concat(glob(path.join(self.basePath, p)));
         }, []);
 
         compilation.plugin("additional-assets", function(cb){
@@ -56,7 +57,7 @@ module.exports.prototype.apply = function(compiler) {
                 // multiple entry chunks
                 var assets = Object.keys(compilation.assets);
 
-                compilation.chunks.forEach(function (chunk, i) {
+                compilation.chunks.forEach(function (chunk) {
                     var key;
 
                     if (self.entryPaths[chunk.name]) {
@@ -66,13 +67,12 @@ module.exports.prototype.apply = function(compiler) {
                         }, []);
 
                         // filter chunk modules for additional files to include ex. .js, .es6,...
-                        var chunkModules = chunk.modules.filter(function (module) {
-                            var ext = path.extname(module.resource);
-                            return self.resolveExtensions.indexOf(ext) > -1;
-                        });
-
-                        // include additional modules
-                        chunkFiles.concat(chunkModules);
+                        for (var j = 0; j < chunk.modules.length; j++) {
+                            var ext = path.extname(chunk.modules[j].resource);
+                            if (self.resolveExtensions.indexOf(ext) > -1) {
+                                chunkFiles.push(chunk.modules[j].resource);
+                            }
+                        }
 
                         // find css asset
                         for (var i = 0; i < assets.length; i++){


### PR DESCRIPTION
As is stands right now, plugin assumes that there is only one entry point in webpack configuration. In that case, plugin will extract all provided html files, plus all dependencies and pass it to purify function.

Problem occurs, when there are multiple entry points, so there are separate bundles of js and css code. We don't want to provide all html and dependencies files to purify function, just files that are tied to specific chunk.

My suggestion is, if there are multiple chunks, execute purify for every chunk with files that are tied to that specific chunk. User has to specifies html entry paths for each chunk.
So, if we have configuration for entry like this: 
    `entry: {`
        `a: "./a",`
        `b: "./b",`
        `c: ["./c", "./d"]`
    `},`
Configuration for plugin would look like this:
`plugins: [`
        `new purify({`
            `basePath: __dirname,`
            `entryPaths: {`
                `a: ["app/views/a/*.html"],`
                `b: ["app/views/b/*.html"],`
                `c: ["app/views/c/*.html"]`
           `}`
        `})`
    `]`

Plugin will execute purify in standard way if either one of this configuration is provided:
- `entry: "./a"`, `entry: ["./a", "./b"]` or `entry: { a: "./a" }`
- `entryPaths` property is not provided.
